### PR TITLE
ShannonLoader fixes for ghidra 10.2.2 compability

### DIFF
--- a/.github/workflows/ShannonLoader.yml
+++ b/.github/workflows/ShannonLoader.yml
@@ -22,7 +22,8 @@ jobs:
         working-directory: reversing/ghidra/ShannonLoader
 
     env:
-      GHIDRA_VERSION: ghidra_10.1.2_PUBLIC
+      GHIDRA_VERSION: ghidra_10.2.2_PUBLIC
+      GHIDRA_BUILDDATE: 20221115
 
     steps:
     - uses: actions/checkout@v2
@@ -35,9 +36,9 @@ jobs:
       with:
         java-version: 11
     - name: Download Ghidra ${{ env.GHIDRA_VERSION }}
-      run: wget -q https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.1.2_build/${GHIDRA_VERSION}_20220125.zip
+      run: wget -q https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.2.2_build/${GHIDRA_VERSION}_${GHIDRA_BUILDDATE}.zip
     - name: Unzip Ghidra
-      run: unzip -q ${GHIDRA_VERSION}_20220125.zip
+      run: unzip -q ${GHIDRA_VERSION}_${GHIDRA_BUILDDATE}.zip
     - name: Build and pack extension
       run: GHIDRA_INSTALL_DIR=$(pwd)/${GHIDRA_VERSION} ./gradlew
     - name: Install extension to Ghidra

--- a/reversing/ghidra/ShannonLoader/README.md
+++ b/reversing/ghidra/ShannonLoader/README.md
@@ -17,7 +17,7 @@ Extract this tar file into its two components, `modem.bin` and `modem_debug.bin`
 * Roadmap: MMU map recovery
 
 ## Building and Testing
-- Ensure you have ``JAVA_HOME`` set to the path of your JDK 11 installation (the default).
+- Ensure you have ``JAVA_HOME`` set to the path of your JDK 17 installation (the default).
 - Set ``GHIDRA_INSTALL_DIR`` to your Ghidra install directory. This can be done in one of the following ways:
     - **Windows**: Running ``set GHIDRA_INSTALL_DIR=<Absolute path to Ghidra without quotations>``
     - **macos/Linux**: Running ``export GHIDRA_INSTALL_DIR=<Absolute path to Ghidra>``

--- a/reversing/ghidra/ShannonLoader/gradle/wrapper/gradle-wrapper.properties
+++ b/reversing/ghidra/ShannonLoader/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/reversing/ghidra/ShannonLoader/src/main/java/adubbz/nx/loader/common/MemoryBlockHelper.java
+++ b/reversing/ghidra/ShannonLoader/src/main/java/adubbz/nx/loader/common/MemoryBlockHelper.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import ghidra.app.util.MemoryBlockUtils;
 import ghidra.app.util.bin.ByteProvider;
 import ghidra.app.util.importer.MessageLog;
-import ghidra.app.util.bin.format.FactoryBundledWithBinaryReader;
 import ghidra.app.util.bin.format.elf.ElfHeader;
 import ghidra.app.util.bin.format.elf.ElfSectionHeader;
 import ghidra.app.util.bin.format.elf.ElfStringTable;

--- a/reversing/ghidra/ShannonLoader/src/main/java/de/hernan/ShannonLoader.java
+++ b/reversing/ghidra/ShannonLoader/src/main/java/de/hernan/ShannonLoader.java
@@ -270,7 +270,7 @@ public class ShannonLoader extends BinaryLoader
     }
 
     @Override
-    protected List<Program> loadProgram(ByteProvider provider, String programName,
+    protected List<LoadedProgram> loadProgram(ByteProvider provider, String programName,
             DomainFolder programFolder, LoadSpec loadSpec, List<Option> options, MessageLog log,
             Object consumer, TaskMonitor monitor)
                     throws IOException, CancelledException 
@@ -296,8 +296,8 @@ public class ShannonLoader extends BinaryLoader
             }
         }
 
-        List<Program> results = new ArrayList<Program>();
-        if (prog != null) results.add(prog);
+        List<LoadedProgram> results = new ArrayList<>();
+        if (prog != null) results.add(new LoadedProgram(prog, programFolder));
         return results;
     }
 


### PR DESCRIPTION
This commit allows to build shannonLoader against ghidra 10.2.2.

However, it likely breaks backwardscompability, as ghidra slightly changed the loadProgram API. Hence, building against earlier versions of Ghidra will likely not work anymore.