### PR TITLE
UPDATE ShannonLoader to Ghidra 11.1.1 API

### DIFF
--- a/reversing/ghidra/ShannonLoader/src/main/java/adubbz/nx/loader/common/MemoryBlockHelper.java
+++ b/reversing/ghidra/ShannonLoader/src/main/java/adubbz/nx/loader/common/MemoryBlockHelper.java
@@ -234,7 +234,7 @@ public class MemoryBlockHelper
     private String memoryPermissions(MemoryBlock block)
     {
       String perms = "";
-      int flags = block.getPermissions();
+      int flags = block.getFlags();
 
       if ((flags & MemoryBlock.READ) != 0)
         perms += "R";


### PR DESCRIPTION
In the `MemoryBlock` class, the method name `getPermissions` is changed to `getFlags` with [Ghidra 11.1.1](https://github.com/NationalSecurityAgency/ghidra/commit/ae475f743bdfce9461d4f1be32ac86d7e8deca9e#diff-d356dde75ebb002881f60608e6b37e72bc665262966e544b3d251ae28f8ae857) causing the compilation of the current `ShannonLoader` to fail.