### PR TITLE
ShannonLoader: update for Ghidra 11.2

### DIFF
--- a/reversing/ghidra/ShannonLoader/gradle/wrapper/gradle-wrapper.properties
+++ b/reversing/ghidra/ShannonLoader/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/reversing/ghidra/ShannonLoader/src/main/java/adubbz/nx/loader/common/MemoryBlockHelper.java
+++ b/reversing/ghidra/ShannonLoader/src/main/java/adubbz/nx/loader/common/MemoryBlockHelper.java
@@ -234,7 +234,7 @@ public class MemoryBlockHelper
     private String memoryPermissions(MemoryBlock block)
     {
       String perms = "";
-      int flags = block.getPermissions();
+      int flags = block.getFlags();
 
       if ((flags & MemoryBlock.READ) != 0)
         perms += "R";


### PR DESCRIPTION
Hi, I tested this extension on Ghidra 11.2, and it requires a small patch to build it. Tested with various Pixel 7 and 9 modem images, and at least memory regions are identified.